### PR TITLE
change name from three-devtools / BACE three-devtools to three-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "three-devtools",
+  "name": "three-tools",
   "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "three-devtools",
+      "name": "three-tools",
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "three-devtools",
+  "name": "three-tools",
   "private": true,
   "version": "0.4.1",
   "description": "BACE three.js developer tools web extension",
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jsantell/three-devtools.git"
+    "url": "https://github.com/oslabs-beta/BACE"
   },
   "author": "BACE",
   "license": "MIT",

--- a/src/app/ContentBridge.js
+++ b/src/app/ContentBridge.js
@@ -174,7 +174,7 @@ export default class ContentBridge extends EventTarget {
         break;
       case 'register':
         this.revision = data.revision;
-        this[$eval](`console.log("three-devtools: debugging three.js r${this.revision}")`);
+        this[$eval](`console.log("three-tools: debugging three.js r${this.revision}")`);
         break;
       case 'committed':
         this[$db].clear();

--- a/src/app/elements/AppElement.js
+++ b/src/app/elements/AppElement.js
@@ -377,7 +377,7 @@ export default class AppElement extends LitElement {
 <div class="flex" state=${this.isReady ? 'ready' : this.needsReload ? 'needs-reload' : 'waiting'} id="container">
   <!-- Reload panes only when needs to reload, but should autoreload normally -->
   <devtools-message visible-when='needs-reload'>
-    <span>BACE Three Devtools requires a page reload.</span>
+    <span>three-tools requires a page reload.</span>
     <devtools-button @click="${() => this.content.reload()}">
       <span>Reload</span>
     </devtools-button>

--- a/src/app/injection.js
+++ b/src/app/injection.js
@@ -12,7 +12,7 @@ const blue = "rgb(120, 250, 228)";
 
 export default `
 
-console.log('%c▲%cthree-devtools%c',
+console.log('%c▲%cthree-tools%c',
   'font-size:150%; color:${green}; text-shadow: -10px 0px ${red}, 10px 0px ${blue}; padding: 0 15px 0 10px;',
   'font-size: 110%; background-color: #666; color:white; padding: 0 5px;',
   'font-size: 110%; background-color: ${blue}; color:#666; padding: 0 5px;');

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -1,7 +1,7 @@
 const connections = new Map();
 
 /**
- * When opening the three-devtools panel, store
+ * When opening the three-tools panel, store
  * a connection to communicate later.
  */
 browser.runtime.onConnect.addListener(port => {

--- a/src/extension/contentScript.js
+++ b/src/extension/contentScript.js
@@ -8,6 +8,7 @@ script.text = `
  * This script injected by the installed three.js developer
  * tools extension.
  * https://github.com/threejs/three-devtools
+ * https://github.com/oslabs-beta/BACE 
  */
 
 const $devtoolsReady = Symbol('devtoolsReady');

--- a/src/extension/devtools.js
+++ b/src/extension/devtools.js
@@ -15,5 +15,5 @@ async function createPanel() {
   // Use `/` to circumvent.
   const icon = '/assets/icon_128.png';
   const url = '/src/app/index.html';
-  const panel = await browser.devtools.panels.create(`BACE-three-devtools`, icon, url);
+  const panel = await browser.devtools.panels.create(`three-tools`, icon, url);
 }


### PR DESCRIPTION
- fix nomenclature / inconsistent naming
- update all names to three-tools in console.logs, devtool panel name, reload message and package.json/package-lock.json 